### PR TITLE
feat: Enable NASA ADS search by title, author, and year

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Please report any bugs, questions, or feature requests in the Github repository.
 - Autoretrieve citation counts when a new item is added to your Zotero library.
 - Retrieve citation counts manually by right-clicking on one or more items in your Zotero library.
 - Works with the following APIs: [Crossref](https://www.crossref.org), [INSPIRE-HEP](https://inspirehep.net), [Semantic Scholar](https://www.semanticscholar.org), and [NASA ADS](https://ui.adsabs.harvard.edu).
+- For NASA ADS, if DOI or arXiv ID is missing, attempts to fetch citations using title, author, and year.
 - _NEW:_ The plugin is compatible with **Zotero 7** (Zotero 6 is **NOT** supported!).
 - _NEW:_ The plugin registers a custom column ("Citation Counts") in your Zotero library so that items can be **ordered by citation count**.
 - _NEW:_ Improved _citation count retrieval operation_ status reporting, including item-specific error messages for those items where a citation count couldn't be retrieved.


### PR DESCRIPTION
This commit enhances the NASA ADS integration by adding a fallback mechanism to search for citations using the paper's title, primary author's last name, and publication year when DOI and arXiv identifiers are not available or do not yield results.

Key changes include:
- Modified `_nasaadsUrl` to construct search queries based on title, author, and year.
- Added `_getItemMetadataForAdsQuery` helper to extract necessary metadata from Zotero items.
- Updated `_retrieveCitationCount` to attempt title-based search for NASA ADS after DOI/arXiv lookups.
- Adjusted `_nasaadsCallback` to log when multiple results are found, using the first.
- Introduced new error messages for title search specific outcomes (e.g., insufficient metadata, no results from title search).
- Added comprehensive integration checks for the new title search functionality, including success cases, no-result cases, and prioritization of existing identifiers.
- Updated `README.md` to inform you of this new capability.