### PR TITLE
feat: Add Semantic Scholar title search capability

### DIFF
--- a/src/citation-counts.ftl
+++ b/src/citation-counts.ftl
@@ -1,0 +1,1 @@
+# Dummy FTL file for testing

--- a/src/zoterocitationcounts.js
+++ b/src/zoterocitationcounts.js
@@ -63,6 +63,7 @@ ZoteroCitationCounts = {
         name: "Semantic Scholar",
         useDoi: true,
         useArxiv: true,
+        useTitleSearch: true,
         methods: {
           urlBuilder: this._semanticScholarUrl,
           responseCallback: this._semanticScholarCallback,
@@ -344,7 +345,7 @@ ZoteroCitationCounts = {
   _updateItem: async function (
     currentItemIndex,
     items,
-    api,
+    api, // This is an object from the APIs array
     progressWindow,
     progressWindowItems
   ) {
@@ -352,7 +353,7 @@ ZoteroCitationCounts = {
     if (currentItemIndex >= items.length) {
       const headlineFinished = await this.l10n.formatValue(
         "citationcounts-progresswindow-finished-headline",
-        { api: api.name }
+        { api: api.name } // api.name is correct here
       );
       progressWindow.changeHeadline(headlineFinished);
       progressWindow.startCloseTimer(5000);
@@ -365,11 +366,12 @@ ZoteroCitationCounts = {
     try {
       const [count, source] = await this._retrieveCitationCount(
         item,
-        api.name,
-        api.useDoi,
-        api.useArxiv,
+        api.name, // Pass the API name
+        api.useDoi, // Pass DOI preference
+        api.useArxiv, // Pass ArXiv preference
         api.methods.urlBuilder,
-        api.methods.responseCallback
+        api.methods.responseCallback,
+        api.useTitleSearch // Pass title search preference
       );
 
       this._setCitationCount(item, source, count);
@@ -540,7 +542,8 @@ ZoteroCitationCounts = {
     useDoi,
     useArxiv,
     urlFunction,
-    requestCallback
+    requestCallback,
+    useTitleSearch // New parameter based on API config
   ) {
     let doiError = null;
     let arxivError = null;
@@ -582,15 +585,13 @@ ZoteroCitationCounts = {
       }
     }
 
-    // NASA ADS Title Search Attempt
-    if (apiName === "NASA ADS") {
-      // Proceed if DOI/arXiv attempts didn't return or if their errors are "not found" types.
-      // Critical errors from DOI/arXiv attempts will be prioritized in the error handling below.
-      const metadata = this._getItemMetadataForAdsQuery(item);
+    // Generic Title Search Attempt (e.g., for NASA ADS, Semantic Scholar if enabled)
+    if (useTitleSearch) {
+      const metadata = this._getItemMetadataForAdsQuery(item); // Using existing function
       if (metadata && metadata.title && (metadata.author || metadata.year)) {
         try {
           const count = await this._sendRequest(
-            urlFunction(metadata, "title_author_year"),
+            urlFunction(metadata, "title_author_year"), // urlFunction will build the correct URL
             requestCallback
           );
           this._log(`Successfully fetched citation count via ${apiName}/Title for item '${item.getField('title') || item.id}'. Count: ${count}`);
@@ -599,11 +600,18 @@ ZoteroCitationCounts = {
           if (error.message === 'citationcounts-progresswindow-error-no-citation-count') {
             this._log(`No citation count found via ${apiName}/Title for item '${item.getField('title') || item.id}'.`);
           }
-          titleError = error;
+          // Prioritize more critical errors (like API key issues from _sendRequest) 
+          // over "no-citation-count" or "insufficient-metadata".
+          if (!titleError || 
+              (titleError.message === 'citationcounts-progresswindow-error-no-citation-count' && error.message !== 'citationcounts-progresswindow-error-no-citation-count') ||
+              (titleError.message === 'citationcounts-progresswindow-error-insufficient-metadata-for-title-search' && error.message !== 'citationcounts-progresswindow-error-insufficient-metadata-for-title-search')) {
+            titleError = error;
+          }
         }
       } else {
-        // Only set this error if no other more critical error (like API key) has already occurred for title.
+        // Set insufficient metadata error only if no more critical error (e.g. API key from a previous title attempt) has been set.
         if (!titleError) { 
+          this._log(`Insufficient metadata for title search for item '${item.getField('title') || item.id}' using ${apiName}.`);
           titleError = new Error("citationcounts-progresswindow-error-insufficient-metadata-for-title-search");
         }
       }
@@ -611,94 +619,124 @@ ZoteroCitationCounts = {
 
     // Final Error Handling
 
-    // Prioritize critical errors (API key, bad response, etc.) over "not found" errors.
-    if (doiError && doiError.message !== "citationcounts-progresswindow-error-no-doi") {
-      this._log(`Failed to retrieve citation count for item '${item.getField('title') || item.id}' after all attempts. Error: ${doiError.message}`);
-      throw doiError;
+    // Prioritize critical errors (API key, bad response, etc.) over "not found" or "insufficient metadata" errors.
+    // A critical error from DOI attempt takes precedence.
+    if (doiError && 
+        doiError.message !== "citationcounts-progresswindow-error-no-doi" && 
+        doiError.message !== "citationcounts-progresswindow-error-no-citation-count") {
+        this._log(`Critical DOI error for ${apiName} for item '${item.getField('title') || item.id}': ${doiError.message}`);
+        throw doiError;
     }
-    if (arxivError && arxivError.message !== "citationcounts-progresswindow-error-no-arxiv") {
-      this._log(`Failed to retrieve citation count for item '${item.getField('title') || item.id}' after all attempts. Error: ${arxivError.message}`);
-      throw arxivError;
+    // A critical error from ArXiv attempt takes next precedence.
+    if (arxivError && 
+        arxivError.message !== "citationcounts-progresswindow-error-no-arxiv" && 
+        arxivError.message !== "citationcounts-progresswindow-error-no-citation-count") {
+        this._log(`Critical ArXiv error for ${apiName} for item '${item.getField('title') || item.id}': ${arxivError.message}`);
+        throw arxivError;
     }
-    // For titleError, "no-citation-count" is a valid "not found" type error from ADS, so don't treat it as critical here.
-    // "insufficient-metadata" is also not critical in the same way as an API key error.
+    // A critical error from Title attempt takes next precedence.
+    // (Includes API key errors, bad API responses, etc. from _sendRequest)
     if (titleError && 
         titleError.message !== "citationcounts-progresswindow-error-no-citation-count" &&
         titleError.message !== "citationcounts-progresswindow-error-insufficient-metadata-for-title-search") {
-      this._log(`Failed to retrieve citation count for item '${item.getField('title') || item.id}' after all attempts. Error: ${titleError.message}`);
-      throw titleError;
+        this._log(`Critical Title Search error for ${apiName} for item '${item.getField('title') || item.id}': ${titleError.message}`);
+        throw titleError;
     }
     
-    // If we're here, all attempts failed or resulted in "not found" or "insufficient metadata" errors.
-    if (apiName === "NASA ADS") {
-      // Check if all avenues for NASA ADS are exhausted or resulted in non-critical errors.
-      const doiFailedOrNotUsed = !useDoi || (doiError && doiError.message === "citationcounts-progresswindow-error-no-doi");
-      const arxivFailedOrNotUsed = !useArxiv || (arxivError && arxivError.message === "citationcounts-progresswindow-error-no-arxiv");
-      // titleError here could be "no-citation-count", "insufficient-metadata", or a critical one already thrown.
-      // We are interested if a title search was attempted and failed non-critically, or was not possible.
-      const titleSearchFailedOrNotPossible = titleError !== null;
+    // If we are here, all recorded errors are of "not found", "no id", or "insufficient metadata" type.
+    // Now, determine the most appropriate "not found" or "cannot attempt" error to throw based on what was attempted.
 
+    const doiAttempted = useDoi;
+    const arxivAttempted = useArxiv;
+    const titleSearchAttempted = useTitleSearch;
 
-      if (doiFailedOrNotUsed && arxivFailedOrNotUsed && titleSearchFailedOrNotPossible) {
-         // If titleError is "insufficient-metadata", that's the most specific.
+    const doiFailedNonCritically = doiError && (doiError.message === "citationcounts-progresswindow-error-no-doi" || doiError.message === "citationcounts-progresswindow-error-no-citation-count");
+    const arxivFailedNonCritically = arxivError && (arxivError.message === "citationcounts-progresswindow-error-no-arxiv" || arxivError.message === "citationcounts-progresswindow-error-no-citation-count");
+    const titleFailedNonCritically = titleError && (titleError.message === "citationcounts-progresswindow-error-no-citation-count" || titleError.message === "citationcounts-progresswindow-error-insufficient-metadata-for-title-search");
+
+    // Case 1: All attempted methods failed non-critically.
+    let allApplicableMethodsFailedNonCritically = true;
+    if (doiAttempted && !doiFailedNonCritically) allApplicableMethodsFailedNonCritically = false;
+    if (arxivAttempted && !arxivFailedNonCritically) allApplicableMethodsFailedNonCritically = false;
+    if (titleSearchAttempted && !titleFailedNonCritically) allApplicableMethodsFailedNonCritically = false;
+    
+    if (allApplicableMethodsFailedNonCritically && (doiAttempted || arxivAttempted || titleSearchAttempted)) {
+      // Special handling for NASA ADS "no results"
+      if (apiName === "NASA ADS" && titleSearchAttempted) { // NASA ADS uses title search as part of its core strategy
+        // If title search itself was due to insufficient metadata, that's the most specific error.
         if (titleError && titleError.message === "citationcounts-progresswindow-error-insufficient-metadata-for-title-search") {
-          this._log(`Failed to retrieve citation count for item '${item.getField('title') || item.id}' after all attempts. Error: ${titleError.message}`);
-          throw titleError;
+            this._log(`NASA ADS: All attempts failed for item '${item.getField('title') || item.id}'. Final error: ${titleError.message}`);
+            throw titleError;
         }
-        // If title search resulted in "no-citation-count" after DOI/arXiv also yielded nothing of substance
-        if (titleError && titleError.message === "citationcounts-progresswindow-error-no-citation-count") {
-            const finalError = new Error("citationcounts-progresswindow-error-nasaads-no-results");
-            this._log(`Failed to retrieve citation count for item '${item.getField('title') || item.id}' after all attempts. Error: ${finalError.message}`);
-            throw finalError;
-        }
-        // If title search itself had a critical error, it would have been thrown above.
-        // If titleError is null here, it means title search was not attempted (e.g. not NASA ADS, or metadata was missing but didn't set titleError - fixed above)
-        // or it was successful (which means we wouldn't be in this error handling block).
-        // So, if titleError is null but doi/arxiv failed, this implies title search was not relevant or didn't even get to set an error.
-        // This case should ideally be covered by "insufficient metadata" or the general "no-doi-or-arxiv" if title wasn't applicable.
-        // Given the logic, if titleSearchFailedOrNotPossible is true, titleError is not null.
-        const finalErrorNasaNoResults = new Error("citationcounts-progresswindow-error-nasaads-no-results");
-        this._log(`Failed to retrieve citation count for item '${item.getField('title') || item.id}' after all attempts. Error: ${finalErrorNasaNoResults.message}`);
-        throw finalErrorNasaNoResults;
+        const finalNasaError = new Error("citationcounts-progresswindow-error-nasaads-no-results");
+        this._log(`NASA ADS: No results from any method for item '${item.getField('title') || item.id}'. Error: ${finalNasaError.message}`);
+        throw finalNasaError;
       }
-      if (titleError) { // If title search failed (e.g. no-citation-count, insufficient-metadata)
-        this._log(`Failed to retrieve citation count for item '${item.getField('title') || item.id}' after all attempts. Error: ${titleError.message}`);
-        throw titleError; 
+
+      // For other APIs (like Semantic Scholar now) or if NASA ADS didn't use title search for some reason
+      if (titleSearchAttempted && titleError && titleError.message === "citationcounts-progresswindow-error-insufficient-metadata-for-title-search") {
+        // If title search couldn't be performed due to metadata, and DOI/ArXiv also failed non-critically
+        this._log(`All attempts for ${apiName} failed for item '${item.getField('title') || item.id}'. Final error: ${titleError.message}`);
+        throw titleError; // "insufficient-metadata..."
       }
+      
+      // Generic "no results from any attempt"
+      const finalErrorAllAttempts = new Error("citationcounts-progresswindow-error-no-results-all-attempts");
+      this._log(`${apiName}: No citation count found after all attempts (DOI, ArXiv, Title if applicable) for item '${item.getField('title') || item.id}'. Error: ${finalErrorAllAttempts.message}`);
+      throw finalErrorAllAttempts;
     }
 
-    // General "Not Found" type errors for any API
-    if (useDoi && doiError && useArxiv && arxivError) { // Both attempted, both are "no-id" type
+    // Case 2: Some attempts failed non-critically, others were not applicable or didn't set an error (should not happen if logic is correct).
+    // Prioritize the "most specific" non-critical error.
+    // If title search failed due to insufficient metadata, and it was the "last resort" or only resort.
+    if (titleSearchAttempted && titleError && titleError.message === "citationcounts-progresswindow-error-insufficient-metadata-for-title-search") {
+        if ((!doiAttempted || doiFailedNonCritically) && (!arxivAttempted || arxivFailedNonCritically)) {
+            this._log(`${apiName}: Title search failed due to insufficient metadata for item '${item.getField('title') || item.id}', other methods also failed or not applicable. Error: ${titleError.message}`);
+            throw titleError;
+        }
+    }
+    
+    // If title search yielded "no citation count" and other methods also failed non-critically or were not applicable.
+    if (titleSearchAttempted && titleError && titleError.message === "citationcounts-progresswindow-error-no-citation-count") {
+        if ((!doiAttempted || doiFailedNonCritically) && (!arxivAttempted || arxivFailedNonCritically)) {
+            this._log(`${apiName}: No citation count from title search for item '${item.getField('title') || item.id}', other methods also failed or not applicable. Error: ${titleError.message}`);
+            throw titleError; // This is "no-citation-count"
+        }
+    }
+
+    // Fallback to DOI/ArXiv specific "not found" errors if title search was not attempted or did not set an error.
+    if (doiAttempted && doiFailedNonCritically && arxivAttempted && arxivFailedNonCritically) {
       const finalErrorNoDoiOrArxiv = new Error("citationcounts-progresswindow-error-no-doi-or-arxiv");
-      this._log(`Failed to retrieve citation count for item '${item.getField('title') || item.id}' after all attempts. Error: ${finalErrorNoDoiOrArxiv.message}`);
+      this._log(`${apiName}: Both DOI and ArXiv lookups failed for item '${item.getField('title') || item.id}'. Error: ${finalErrorNoDoiOrArxiv.message}`);
       throw finalErrorNoDoiOrArxiv;
     }
-    if (useDoi && doiError) { // Only DOI attempted (or arXiv not attempted/successful) and DOI is "no-id"
-      this._log(`Failed to retrieve citation count for item '${item.getField('title') || item.id}' after all attempts. Error: ${doiError.message}`);
-      throw doiError;
+    if (doiAttempted && doiFailedNonCritically) {
+      this._log(`${apiName}: DOI lookup failed for item '${item.getField('title') || item.id}'. Error: ${doiError.message}`);
+      throw doiError; // "no-doi" or "no-citation-count" from DOI
     }
-    if (useArxiv && arxivError) { // Only arXiv attempted (or DOI not attempted/successful) and arXiv is "no-id"
-      this._log(`Failed to retrieve citation count for item '${item.getField('title') || item.id}' after all attempts. Error: ${arxivError.message}`);
-      throw arxivError;
+    if (arxivAttempted && arxivFailedNonCritically) {
+      this._log(`${apiName}: ArXiv lookup failed for item '${item.getField('title') || item.id}'. Error: ${arxivError.message}`);
+      throw arxivError; // "no-arxiv" or "no-citation-count" from ArXiv
     }
 
-    // Fallback if no specific error was thrown. This indicates an unhandled case or an API configured with no valid ID types.
-    // If an API is configured (e.g. useDoi=true) but no error was set (e.g. _getDoi didn't throw, _sendRequest didn't throw but we still didn't return)
-    // this is an internal logic issue.
-    if (useDoi || useArxiv || apiName === "NASA ADS") {
-      // If any retrieval method was supposed to be active but we reached here without throwing.
-      // This might happen if e.g. useDoi is true, but doiError is null (somehow).
-      // This path should ideally not be reached if logic is perfect.
+    // Fallback for unhandled cases or configuration issues.
+    let attemptedMethods = [];
+    if (doiAttempted) attemptedMethods.push("DOI");
+    if (arxivAttempted) attemptedMethods.push("ArXiv");
+    if (titleSearchAttempted) attemptedMethods.push("Title");
+
+    if (attemptedMethods.length > 0) {
+      // This means at least one method was configured, but we didn't return success and didn't throw a specific error above.
+      // This might indicate an error in the logic (e.g., a method was attempted, didn't succeed, but its error variable was not set).
       const unknownError = new Error("citationcounts-progresswindow-error-unknown");
-      this._log(`Internal error: Reached end of _retrieveCitationCount for ${apiName} without success or specific error. DOI error: ${doiError}, ArXiv error: ${arxivError}, Title error: ${titleError}. Surfacing as: ${unknownError.message}`);
-      throw unknownError; // A generic "unknown" or "internal"
+      this._log(`Internal error: Reached end of _retrieveCitationCount for ${apiName} for item '${item.getField('title') || item.id}' with methods (${attemptedMethods.join(', ')}) enabled but no success or specific error. DOI error: ${doiError}, ArXiv error: ${arxivError}, Title error: ${titleError}. Surfacing as: ${unknownError.message}`);
+      throw unknownError;
+    } else {
+      // This means the API was called with no retrieval methods enabled (e.g. useDoi=false, useArxiv=false, useTitleSearch=false).
+      const internalError = new Error("citationcounts-internal-error-no-retrieval-methods");
+      this._log(`Configuration error: _retrieveCitationCount called for ${apiName} for item '${item.getField('title') || item.id}' with no valid ID types (DOI, ArXiv, TitleSearch) enabled. Error: ${internalError.message}`);
+      throw internalError;
     }
-    
-    // If the API was somehow called with no valid types (e.g. useDoi=false, useArxiv=false, and not NASA ADS)
-    // This is an internal configuration error.
-    const internalError = new Error("citationcounts-internal-error");
-    this._log(`Configuration error: _retrieveCitationCount called for ${apiName} with no valid ID types enabled. Error: ${internalError.message}`);
-    throw internalError; // Or a more specific "misconfigured API" error
   },
 
   /////////////////////////////////////////////
@@ -722,16 +760,65 @@ ZoteroCitationCounts = {
   },
 
   _semanticScholarUrl: function (id, type) {
-    const prefix = type === "doi" ? "" : "arXiv:";
-    return `https://api.semanticscholar.org/graph/v1/paper/${prefix}${id}?fields=citationCount`;
+    if (type === "title_author_year") {
+      let queryString = "";
+      if (id && id.title) {
+        queryString += `title:${encodeURIComponent(id.title)}`;
+      }
+      if (id && id.author) {
+        queryString += `${queryString ? "+" : ""}author:${encodeURIComponent(
+          id.author
+        )}`;
+      }
+      if (id && id.year) {
+        queryString += `${queryString ? "+" : ""}year:${encodeURIComponent(
+          id.year
+        )}`;
+      }
+      return `https://api.semanticscholar.org/graph/v1/paper/search?query=${queryString}&fields=citationCount,externalIds`;
+    } else {
+      // Existing logic for DOI/ArXiv
+      const prefix = type === "doi" ? "" : "arXiv:";
+      return `https://api.semanticscholar.org/graph/v1/paper/${prefix}${id}?fields=citationCount`;
+    }
   },
 
   // The callback can be async if we want.
   _semanticScholarCallback: async function (response) {
-    count = response["citationCount"];
+    let count;
 
     // throttle Semantic Scholar so we don't reach limit.
+    // This needs to be done before any return, regardless of path.
     await new Promise((r) => setTimeout(r, 3000));
+
+    if (response.data) {
+      // Handle search results
+      if (response.data.length > 1) {
+        this._log(
+          `Semantic Scholar query returned ${response.data.length} results. Using the first one.`
+        );
+      }
+      if (response.data.length > 0 && response.data[0].citationCount !== null && response.data[0].citationCount !== undefined) {
+        count = response.data[0].citationCount;
+        // Optionally, one could also extract and use response.data[0].externalIds here if needed later.
+      } else {
+        this._log(
+          "Semantic Scholar search response did not contain expected citationCount in the first result or no results found. Response: " +
+            JSON.stringify(response)
+        );
+        return null; // Will be caught by parseInt validation in _sendRequest
+      }
+    } else if (response.citationCount !== null && response.citationCount !== undefined) {
+      // Handle direct DOI/ArXiv lookup
+      count = response.citationCount;
+    } else {
+      this._log(
+        "Semantic Scholar response did not contain expected citationCount. Response: " +
+          JSON.stringify(response)
+      );
+      return null; // Will be caught by parseInt validation in _sendRequest
+    }
+
     return count;
   },
 

--- a/test/integration/semanticscholar.integration.test.js
+++ b/test/integration/semanticscholar.integration.test.js
@@ -1,0 +1,405 @@
+const { expect } = require("chai");
+const sinon = require("sinon");
+const fs = require("fs");
+const path = require("path");
+
+// Load the ZoteroCitationCounts module
+const ZoteroCitationCounts = require("../../src/zoterocitationcounts.js");
+
+describe("Semantic Scholar Integration Tests", () => {
+  let sandbox;
+  let mockZotero;
+  let mockItem;
+  let semanticScholarAPI;
+  const today = "2024-07-27"; // Fixed date for consistent testing
+
+  // Helper function to create a mock Zotero item
+  const createMockItem = (props) => {
+    const item = {
+      id: props.id || 1,
+      _changed: false,
+      isFeedItem: false,
+      getField: sinon.stub(),
+      setField: sinon.stub().callsFake(function() { item._changed = true; }),
+      saveTx: sinon.stub().resolves(),
+      getCreators: sinon.stub().returns(props.creators || []),
+    };
+    item.getField.withArgs("title").returns(props.title || "");
+    item.getField.withArgs("DOI").returns(props.DOI || "");
+    item.getField.withArgs("url").returns(props.url || ""); // For arXiv
+    item.getField.withArgs("date").returns(props.date || "");
+    item.getField.withArgs("year").returns(props.year || ""); // For _getItemMetadataForAdsQuery
+    item.getField.withArgs("extra").returns(props.extra || "");
+    return item;
+  };
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+
+    // Mock global Zotero object
+    mockZotero = {
+      Prefs: {
+        get: sandbox.stub(),
+        set: sandbox.stub(),
+      },
+      debug: sandbox.stub(),
+      ProgressWindow: sandbox.stub().returns({
+        changeHeadline: sandbox.stub(),
+        show: sandbox.stub(),
+        startCloseTimer: sandbox.stub(),
+        ItemProgress: sandbox.stub().returns({
+          setIcon: sandbox.stub(),
+          setText: sandbox.stub(),
+          setProgress: sandbox.stub(),
+          setError: sandbox.stub(),
+        }),
+      }),
+      getActiveZoteroPane: sandbox.stub().returns({
+        getSelectedItems: sandbox.stub().returns([mockItem]), // Default behavior
+      }),
+      Localization: sandbox.stub().returns({
+        formatValue: sandbox.stub().callsFake(async (key, args) => {
+          let message = key; // Default to key if no specific message is needed
+          if (args) {
+            message += ": " + JSON.stringify(args);
+          }
+          // Add specific messages for errors if needed for assertions
+          if (key === "citationcounts-progresswindow-error-no-results-all-attempts") {
+            message = "No citation count found after all attempts.";
+          } else if (key === "citationcounts-progresswindow-error-insufficient-metadata-for-title-search") {
+            message = "Insufficient metadata for title search.";
+          } else if (key === "citationcounts-progresswindow-error-bad-api-response") {
+            message = "Bad API response.";
+          } else if (key === "citationcounts-progresswindow-error-no-doi") {
+            message = "No DOI found for item.";
+          } else if (key === "citationcounts-progresswindow-error-no-arxiv") {
+            message = "No arXiv ID found for item.";
+          }
+          return message;
+        }),
+      }),
+      hiDPI: true, // Or false, depending on what you want to test
+      // Ensure ZoteroCitationCounts can find its FTL file
+      File: {
+        exists: sandbox.stub().returns(true),
+        getContentsAsync: sandbox.stub().resolves(""), // Mock FTL content
+      },
+      getMainWindow: sandbox.stub().returns({ // Mock for MozXULElement
+        MozXULElement: {
+            insertFTLIfNeeded: sandbox.stub(),
+        }
+      }),
+    };
+    global.Zotero = mockZotero;
+
+    // Stub fetch
+    global.fetch = sandbox.stub();
+
+    // Control date
+    sandbox.stub(Date.prototype, 'toISOString').returns(`${today}T12:00:00.000Z`);
+
+    // Initialize ZoteroCitationCounts
+    // Need to ensure the path to FTL is correctly handled if it's dynamic
+    const ftlPath = path.resolve(__dirname, '../../src/citation-counts.ftl');
+    if (!fs.existsSync(ftlPath)) {
+        // Create a dummy FTL file if it doesn't exist, to prevent init errors
+        fs.writeFileSync(ftlPath, "# Dummy FTL file for testing\n");
+    }
+
+    ZoteroCitationCounts.init({
+      id: "zotero-citation-counts",
+      version: "1.0.0",
+      rootURI: "chrome://zoterocitationcounts/",
+    });
+    
+    // Wait for l10n to be ready if it's async in init (it is due to new Localization)
+    // This can be tricky; for now, we assume formatValue is ready after init.
+    // If l10n setup is async and causes issues, a small delay or a more robust wait might be needed.
+    // Or, if l10n.formatValue is called immediately in init, mock it before init.
+    // For this setup, we'll mock it after init, assuming it's primarily used by updateItems.
+    ZoteroCitationCounts.l10n.formatValue = mockZotero.Localization().formatValue;
+
+
+    semanticScholarAPI = ZoteroCitationCounts.APIs.find(
+      (api) => api.key === "semanticscholar"
+    );
+    expect(semanticScholarAPI).to.exist;
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    delete global.Zotero;
+    delete global.fetch;
+    // Clean up dummy FTL if created - be careful if it's a real file
+    // const ftlPath = path.resolve(__dirname, '../../src/citation-counts.ftl');
+    // if (fs.existsSync(ftlPath) && fs.readFileSync(ftlPath, 'utf8').startsWith("# Dummy FTL file for testing")) {
+    //     fs.unlinkSync(ftlPath);
+    // }
+  });
+
+  describe("Semantic Scholar API Tests", () => {
+    it("Scenario 1: Successful fetch and update via DOI", async () => {
+      mockItem = createMockItem({ DOI: "10.1000/xyz123" });
+      mockZotero.getActiveZoteroPane().getSelectedItems.returns([mockItem]);
+
+      global.fetch.resolves({
+        ok: true,
+        json: async () => ({
+          paperId: "abcdef123456",
+          externalIds: { DOI: "10.1000/xyz123" },
+          citationCount: 123,
+        }),
+      });
+
+      await ZoteroCitationCounts.updateItems([mockItem], semanticScholarAPI);
+
+      const expectedUrl =
+        "https://api.semanticscholar.org/graph/v1/paper/10.1000%2Fxyz123?fields=citationCount";
+      expect(global.fetch.calledOnceWith(expectedUrl)).to.be.true;
+      expect(mockItem.setField.calledOnceWith("extra", `123 citations (Semantic Scholar/DOI) [${today}]`)).to.be.true;
+      expect(mockItem.saveTx.calledOnce).to.be.true;
+      
+      // Check progress window
+      const pwInstance = mockZotero.ProgressWindow();
+      expect(pwInstance.changeHeadline.called).to.be.true;
+      const itemProgressInstance = pwInstance.ItemProgress();
+      expect(itemProgressInstance.setIcon.calledWith(ZoteroCitationCounts.icon("tick"))).to.be.true;
+      expect(itemProgressInstance.setProgress.calledWith(100)).to.be.true;
+
+      // Check for throttle - fetch should be called, then callback has await.
+      // Direct timing is hard, but we know fetch was called.
+      // A more robust test might involve sinon.useFakeTimers() and advancing the clock.
+      // For now, successful call implies callback was entered.
+    });
+
+    it("Scenario 2: Successful fetch and update via arXiv ID", async () => {
+      mockItem = createMockItem({ url: "https://arxiv.org/abs/2101.00001" });
+      mockZotero.getActiveZoteroPane().getSelectedItems.returns([mockItem]);
+
+      global.fetch.resolves({
+        ok: true,
+        json: async () => ({
+          paperId: "abcdef123456",
+          externalIds: { ArXiv: "2101.00001" },
+          citationCount: 456,
+        }),
+      });
+
+      await ZoteroCitationCounts.updateItems([mockItem], semanticScholarAPI);
+
+      const expectedUrl =
+        "https://api.semanticscholar.org/graph/v1/paper/arXiv:2101.00001?fields=citationCount";
+      expect(global.fetch.calledOnceWith(expectedUrl)).to.be.true;
+      expect(mockItem.setField.calledOnceWith("extra", `456 citations (Semantic Scholar/arXiv) [${today}]`)).to.be.true;
+      expect(mockItem.saveTx.calledOnce).to.be.true;
+    });
+
+    it("Scenario 3: Successful fetch and update via Title/Author/Year Search", async () => {
+      mockItem = createMockItem({
+        title: "Test Paper Title",
+        creators: [{ lastName: "Doe", name: "John Doe" }],
+        year: "2023",
+        date: "2023-01-15", // _getItemMetadataForAdsQuery prefers year field but can use date
+      });
+      mockZotero.getActiveZoteroPane().getSelectedItems.returns([mockItem]);
+      
+      global.fetch.resolves({
+        ok: true,
+        json: async () => ({
+          total: 1,
+          data: [
+            {
+              paperId: "zyxwvu987654",
+              externalIds: { DOI: "10.9999/testdoi" },
+              citationCount: 42,
+            },
+          ],
+        }),
+      });
+
+      await ZoteroCitationCounts.updateItems([mockItem], semanticScholarAPI);
+      
+      const expectedQuery = "title%3ATest%20Paper%20Title%2Bauthor%3ADoe%2Byear%3A2023";
+      const expectedUrl = `https://api.semanticscholar.org/graph/v1/paper/search?query=${expectedQuery}&fields=citationCount,externalIds`;
+      
+      expect(global.fetch.calledOnceWith(expectedUrl)).to.be.true;
+      expect(mockItem.setField.calledOnceWith("extra", `42 citations (Semantic Scholar/Title) [${today}]`)).to.be.true;
+      expect(mockItem.saveTx.calledOnce).to.be.true;
+    });
+
+    it("Scenario 4: Title Search - No Results", async () => {
+      mockItem = createMockItem({
+        title: "Obscure Paper",
+        creators: [{ lastName: "Nobody" }],
+        year: "2020",
+        date: "2020-01-01",
+      });
+      mockZotero.getActiveZoteroPane().getSelectedItems.returns([mockItem]);
+
+      global.fetch.resolves({
+        ok: true,
+        json: async () => ({ total: 0, data: [] }), // Empty result
+      });
+
+      await ZoteroCitationCounts.updateItems([mockItem], semanticScholarAPI);
+
+      const expectedQuery = "title%3AObscure%20Paper%2Bauthor%3ANobody%2Byear%3A2020";
+      const expectedUrl = `https://api.semanticscholar.org/graph/v1/paper/search?query=${expectedQuery}&fields=citationCount,externalIds`;
+      expect(global.fetch.calledOnceWith(expectedUrl)).to.be.true;
+      expect(mockItem.setField.called).to.be.false; // Should not set field on no results
+      expect(mockItem.saveTx.called).to.be.false;
+
+      const pwInstance = mockZotero.ProgressWindow();
+      const itemProgressInstance = pwInstance.ItemProgress();
+      expect(itemProgressInstance.setError.calledOnce).to.be.true;
+      
+      const formatValueStub = ZoteroCitationCounts.l10n.formatValue;
+      expect(formatValueStub.calledWith("citationcounts-progresswindow-error-no-results-all-attempts", { api: "Semantic Scholar" })).to.be.true;
+      // Check Zotero.debug for the specific error message logged in _retrieveCitationCount
+      sinon.assert.calledWith(mockZotero.debug, sinon.match("No citation count found via Semantic Scholar/Title"));
+      sinon.assert.calledWith(mockZotero.debug, sinon.match("No citation count found after all attempts (DOI, ArXiv, Title if applicable) for item 'Obscure Paper'"));
+    });
+
+    it("Scenario 5: Title Search - Insufficient Metadata", async () => {
+      mockItem = createMockItem({ title: "A Title Alone" }); // Missing author/year
+      mockZotero.getActiveZoteroPane().getSelectedItems.returns([mockItem]);
+
+      await ZoteroCitationCounts.updateItems([mockItem], semanticScholarAPI);
+
+      expect(global.fetch.called).to.be.false; // Fetch should not be called
+      expect(mockItem.setField.called).to.be.false;
+      expect(mockItem.saveTx.called).to.be.false;
+
+      const pwInstance = mockZotero.ProgressWindow();
+      const itemProgressInstance = pwInstance.ItemProgress();
+      expect(itemProgressInstance.setError.calledOnce).to.be.true;
+      const formatValueStub = ZoteroCitationCounts.l10n.formatValue;
+      expect(formatValueStub.calledWith("citationcounts-progresswindow-error-insufficient-metadata-for-title-search", { api: "Semantic Scholar" })).to.be.true;
+      sinon.assert.calledWith(mockZotero.debug, sinon.match("Insufficient metadata for title search for item 'A Title Alone' using Semantic Scholar."));
+    });
+
+    it("Scenario 6: Prioritization - DOI Search Preferred over Title Search", async () => {
+      mockItem = createMockItem({
+        DOI: "10.1000/realdoi",
+        title: "A Real Title",
+        creators: [{ lastName: "Author" }],
+        year: "2021",
+        date: "2021-01-01",
+      });
+      mockZotero.getActiveZoteroPane().getSelectedItems.returns([mockItem]);
+
+      global.fetch.resolves({ // Mock for DOI success
+        ok: true,
+        json: async () => ({ citationCount: 777 }),
+      });
+
+      await ZoteroCitationCounts.updateItems([mockItem], semanticScholarAPI);
+
+      const expectedDoiUrl = "https://api.semanticscholar.org/graph/v1/paper/10.1000%2Frealdoi?fields=citationCount";
+      expect(global.fetch.calledOnceWith(expectedDoiUrl)).to.be.true; // Only DOI url
+      
+      const titleQuery = "title%3AA%20Real%20Title%2Bauthor%3AAuthor%2Byear%3A2021";
+      const expectedTitleUrl = `https://api.semanticscholar.org/graph/v1/paper/search?query=${titleQuery}&fields=citationCount,externalIds`;
+      expect(global.fetch.neverCalledWith(expectedTitleUrl)).to.be.true; // Title URL should not be called
+
+      expect(mockItem.setField.calledOnceWith("extra", `777 citations (Semantic Scholar/DOI) [${today}]`)).to.be.true;
+    });
+
+    it("Scenario 7: Prioritization - arXiv Search Preferred over Title Search (No DOI)", async () => {
+      mockItem = createMockItem({
+        url: "http://arxiv.org/abs/2202.00002",
+        title: "An ArXiv Title",
+        creators: [{ lastName: "Scientist" }],
+        year: "2022",
+        date: "2022-01-01",
+      });
+       mockZotero.getActiveZoteroPane().getSelectedItems.returns([mockItem]);
+
+      global.fetch.resolves({ // Mock for ArXiv success
+        ok: true,
+        json: async () => ({ citationCount: 888 }),
+      });
+
+      await ZoteroCitationCounts.updateItems([mockItem], semanticScholarAPI);
+
+      const expectedArxivUrl = "https://api.semanticscholar.org/graph/v1/paper/arXiv:2202.00002?fields=citationCount";
+      expect(global.fetch.calledOnceWith(expectedArxivUrl)).to.be.true;
+
+      const titleQuery = "title%3AAn%20ArXiv%20Title%2Bauthor%3AScientist%2Byear%3A2022";
+      const expectedTitleUrl = `https://api.semanticscholar.org/graph/v1/paper/search?query=${titleQuery}&fields=citationCount,externalIds`;
+      expect(global.fetch.neverCalledWith(expectedTitleUrl)).to.be.true;
+
+      expect(mockItem.setField.calledOnceWith("extra", `888 citations (Semantic Scholar/arXiv) [${today}]`)).to.be.true;
+    });
+
+    it("Scenario 8: Fallback - DOI fails (no-id), arXiv fails (no-id), Title Search Succeeds", async () => {
+      mockItem = createMockItem({
+        DOI: "10.0000/nonexistentdoi", // Will cause "no-doi" or "no-citation-count"
+        url: "http://arxiv.org/abs/0000.00000", // Will cause "no-arxiv" or "no-citation-count"
+        title: "Fallback Title",
+        creators: [{ lastName: "Persistent" }],
+        year: "2019",
+        date: "2019-01-01",
+      });
+      mockZotero.getActiveZoteroPane().getSelectedItems.returns([mockItem]);
+      
+      const doiUrl = "https://api.semanticscholar.org/graph/v1/paper/10.0000%2Fnonexistentdoi?fields=citationCount";
+      const arxivUrl = "https://api.semanticscholar.org/graph/v1/paper/arXiv:0000.00000?fields=citationCount";
+      const titleQuery = "title%3AFallback%20Title%2Bauthor%3APersistent%2Byear%3A2019";
+      const titleUrl = `https://api.semanticscholar.org/graph/v1/paper/search?query=${titleQuery}&fields=citationCount,externalIds`;
+
+      // Mock fetch logic
+      global.fetch
+        .withArgs(doiUrl).resolves({ ok: true, json: async () => ({ citationCount: null }) }) // Simulate no count for DOI
+        .withArgs(arxivUrl).resolves({ ok: true, json: async () => ({ citationCount: null }) }) // Simulate no count for arXiv
+        .withArgs(titleUrl).resolves({ // Successful title search
+          ok: true,
+          json: async () => ({ total: 1, data: [{ citationCount: 99 }] }),
+        });
+
+      await ZoteroCitationCounts.updateItems([mockItem], semanticScholarAPI);
+
+      expect(global.fetch.calledWith(doiUrl)).to.be.true;
+      expect(global.fetch.calledWith(arxivUrl)).to.be.true;
+      expect(global.fetch.calledWith(titleUrl)).to.be.true;
+      expect(global.fetch.callCount).to.equal(3); // All three should be called
+
+      expect(mockItem.setField.calledOnceWith("extra", `99 citations (Semantic Scholar/Title) [${today}]`)).to.be.true;
+      sinon.assert.calledWith(mockZotero.debug, sinon.match("No citation count found via Semantic Scholar/DOI for item 'Fallback Title'"));
+      sinon.assert.calledWith(mockZotero.debug, sinon.match("No citation count found via Semantic Scholar/arXiv for item 'Fallback Title'"));
+      sinon.assert.calledWith(mockZotero.debug, sinon.match("Successfully fetched citation count via Semantic Scholar/Title for item 'Fallback Title'. Count: 99"));
+    });
+    
+    it("Scenario 9: API Error during Title Search (e.g., 500 server error)", async () => {
+      mockItem = createMockItem({
+        title: "Error Paper",
+        creators: [{ lastName: "Unlucky" }],
+        year: "2024",
+        date: "2024-01-01",
+      });
+      mockZotero.getActiveZoteroPane().getSelectedItems.returns([mockItem]);
+
+      const titleQuery = "title%3AError%20Paper%2Bauthor%3AUnlucky%2Byear%3A2024";
+      const titleUrl = `https://api.semanticscholar.org/graph/v1/paper/search?query=${titleQuery}&fields=citationCount,externalIds`;
+
+      global.fetch.withArgs(titleUrl).resolves({
+        ok: false, // API error
+        status: 500,
+        json: async () => ({ message: "Internal Server Error" }),
+      });
+
+      await ZoteroCitationCounts.updateItems([mockItem], semanticScholarAPI);
+
+      expect(global.fetch.calledOnceWith(titleUrl)).to.be.true;
+      expect(mockItem.setField.called).to.be.false;
+      expect(mockItem.saveTx.called).to.be.false;
+
+      const pwInstance = mockZotero.ProgressWindow();
+      const itemProgressInstance = pwInstance.ItemProgress();
+      expect(itemProgressInstance.setError.calledOnce).to.be.true;
+      const formatValueStub = ZoteroCitationCounts.l10n.formatValue;
+      expect(formatValueStub.calledWith("citationcounts-progresswindow-error-bad-api-response", { api: "Semantic Scholar" })).to.be.true;
+      sinon.assert.calledWith(mockZotero.debug, sinon.match(`Bad API response for ${titleUrl}: status 500`));
+    });
+  });
+});

--- a/test/unit/zoterocitationcounts.test.js
+++ b/test/unit/zoterocitationcounts.test.js
@@ -90,6 +90,159 @@ describe('ZoteroCitationCounts', function() {
       expect(actualUrl).to.equal(expectedUrl);
     });
   });
+
+  describe('_semanticScholarUrl', function() {
+    it('should construct the correct URL for DOI lookup', function() {
+      const id = '10.1000/xyz123';
+      const type = 'doi';
+      const actualUrl = global.ZoteroCitationCounts._semanticScholarUrl(id, type);
+      const expectedUrl = `https://api.semanticscholar.org/graph/v1/paper/${encodeURIComponent(id)}?fields=citationCount`;
+      expect(actualUrl).to.equal(expectedUrl);
+    });
+
+    it('should construct the correct URL for arXiv lookup', function() {
+      const id = '2303.12345';
+      const type = 'arxiv';
+      const actualUrl = global.ZoteroCitationCounts._semanticScholarUrl(id, type);
+      const expectedUrl = `https://api.semanticscholar.org/graph/v1/paper/arXiv:${encodeURIComponent(id)}?fields=citationCount`;
+      expect(actualUrl).to.equal(expectedUrl);
+    });
+
+    it('should construct the correct URL for title/author/year search with all fields', function() {
+      const metadata = {
+        title: "A Test Paper",
+        author: "Doe, J.", // Assuming author might have comma, should be encoded
+        year: "2023"
+      };
+      const type = 'title_author_year';
+      const actualUrl = global.ZoteroCitationCounts._semanticScholarUrl(metadata, type);
+      const expectedQuery = `title:${encodeURIComponent(metadata.title)}+author:${encodeURIComponent(metadata.author)}+year:${encodeURIComponent(metadata.year)}`;
+      const expectedUrl = `https://api.semanticscholar.org/graph/v1/paper/search?query=${expectedQuery}&fields=citationCount,externalIds`;
+      expect(actualUrl).to.equal(expectedUrl);
+    });
+
+    it('should construct the correct URL for title/author/year search with title and author only', function() {
+      const metadata = {
+        title: "Another Test Paper",
+        author: "Smith"
+      };
+      const type = 'title_author_year';
+      const actualUrl = global.ZoteroCitationCounts._semanticScholarUrl(metadata, type);
+      const expectedQuery = `title:${encodeURIComponent(metadata.title)}+author:${encodeURIComponent(metadata.author)}`;
+      const expectedUrl = `https://api.semanticscholar.org/graph/v1/paper/search?query=${expectedQuery}&fields=citationCount,externalIds`;
+      expect(actualUrl).to.equal(expectedUrl);
+    });
+
+    it('should construct the correct URL for title/author/year search with title and year only', function() {
+      const metadata = {
+        title: "A Third Test Paper",
+        year: "2021"
+      };
+      const type = 'title_author_year';
+      const actualUrl = global.ZoteroCitationCounts._semanticScholarUrl(metadata, type);
+      const expectedQuery = `title:${encodeURIComponent(metadata.title)}+year:${encodeURIComponent(metadata.year)}`;
+      const expectedUrl = `https://api.semanticscholar.org/graph/v1/paper/search?query=${expectedQuery}&fields=citationCount,externalIds`;
+      expect(actualUrl).to.equal(expectedUrl);
+    });
+
+    it('should construct the correct URL for title/author/year search with title only', function() {
+      const metadata = {
+        title: "Title Only Paper"
+      };
+      const type = 'title_author_year';
+      const actualUrl = global.ZoteroCitationCounts._semanticScholarUrl(metadata, type);
+      const expectedQuery = `title:${encodeURIComponent(metadata.title)}`;
+      const expectedUrl = `https://api.semanticscholar.org/graph/v1/paper/search?query=${expectedQuery}&fields=citationCount,externalIds`;
+      expect(actualUrl).to.equal(expectedUrl);
+    });
+  });
+
+  describe('_semanticScholarCallback', function() {
+    let clock;
+
+    beforeEach(function() {
+      // Use fake timers to control setTimeout for throttling tests
+      clock = sinon.useFakeTimers();
+    });
+
+    afterEach(function() {
+      clock.restore();
+    });
+
+    it('should return citationCount for direct DOI/ArXiv lookup response', async function() {
+      const mockResponse = {
+        paperId: "abcdef123456",
+        citationCount: 123
+      };
+      const count = await global.ZoteroCitationCounts._semanticScholarCallback(mockResponse);
+      expect(count).to.equal(123);
+    });
+
+    it('should return citationCount from the first result for title search response', async function() {
+      const mockResponse = {
+        total: 1,
+        data: [
+          { paperId: "zyxwvu987654", citationCount: 42, externalIds: {} }
+        ]
+      };
+      const count = await global.ZoteroCitationCounts._semanticScholarCallback(mockResponse);
+      expect(count).to.equal(42);
+    });
+
+    it('should log and use first result if title search returns multiple results', async function() {
+      const mockResponse = {
+        total: 2,
+        data: [
+          { paperId: "zyxwvu987654", citationCount: 77 },
+          { paperId: "abcdef123456", citationCount: 88 }
+        ]
+      };
+      await global.ZoteroCitationCounts._semanticScholarCallback(mockResponse);
+      expect(global.Zotero.debug.calledWith(sinon.match(/Semantic Scholar query returned 2 results. Using the first one./))).to.be.true;
+    });
+    
+    it('should return null if direct lookup response has no citationCount', async function() {
+        const mockResponse = { paperId: "abcdef123456" }; // Missing citationCount
+        const count = await global.ZoteroCitationCounts._semanticScholarCallback(mockResponse);
+        expect(count).to.be.null;
+        expect(global.Zotero.debug.calledWith(sinon.match(/Semantic Scholar response did not contain expected citationCount/))).to.be.true;
+    });
+
+    it('should return null if title search response is empty', async function() {
+      const mockResponse = { total: 0, data: [] };
+      const count = await global.ZoteroCitationCounts._semanticScholarCallback(mockResponse);
+      expect(count).to.be.null;
+      expect(global.Zotero.debug.calledWith(sinon.match(/Semantic Scholar search response did not contain expected citationCount in the first result or no results found/))).to.be.true;
+    });
+
+    it('should return null if title search first result has no citationCount', async function() {
+      const mockResponse = {
+        total: 1,
+        data: [{ paperId: "zyxwvu987654" }] // Missing citationCount
+      };
+      const count = await global.ZoteroCitationCounts._semanticScholarCallback(mockResponse);
+      expect(count).to.be.null;
+      expect(global.Zotero.debug.calledWith(sinon.match(/Semantic Scholar search response did not contain expected citationCount in the first result or no results found/))).to.be.true;
+    });
+    
+    it('should apply a 3-second throttle', async function() {
+      const mockResponse = { citationCount: 10 };
+      const callbackPromise = global.ZoteroCitationCounts._semanticScholarCallback(mockResponse);
+      
+      // Check that it's not resolved immediately
+      let resolved = false;
+      callbackPromise.then(() => resolved = true);
+
+      await clock.tickAsync(2999); // Advance time by just under 3 seconds
+      expect(resolved).to.be.false;
+
+      await clock.tickAsync(1); // Advance time by 1ms to cross the 3000ms threshold
+      expect(resolved).to.be.true; // Now it should be resolved
+      
+      const count = await callbackPromise;
+      expect(count).to.equal(10);
+    });
+  });
   
   describe('getPref', function() {
     it('should call Zotero.Prefs.get with the correct preference key', function() {

--- a/test/unit/zoterocitationcounts.test.js
+++ b/test/unit/zoterocitationcounts.test.js
@@ -174,7 +174,9 @@ describe('ZoteroCitationCounts', function() {
         paperId: "abcdef123456",
         citationCount: 123
       };
-      const count = await global.ZoteroCitationCounts._semanticScholarCallback(mockResponse);
+      const promise = global.ZoteroCitationCounts._semanticScholarCallback(mockResponse);
+      await clock.tickAsync(3001);
+      const count = await promise;
       expect(count).to.equal(123);
     });
 
@@ -185,7 +187,9 @@ describe('ZoteroCitationCounts', function() {
           { paperId: "zyxwvu987654", citationCount: 42, externalIds: {} }
         ]
       };
-      const count = await global.ZoteroCitationCounts._semanticScholarCallback(mockResponse);
+      const promise = global.ZoteroCitationCounts._semanticScholarCallback(mockResponse);
+      await clock.tickAsync(3001);
+      const count = await promise;
       expect(count).to.equal(42);
     });
 
@@ -197,20 +201,26 @@ describe('ZoteroCitationCounts', function() {
           { paperId: "abcdef123456", citationCount: 88 }
         ]
       };
-      await global.ZoteroCitationCounts._semanticScholarCallback(mockResponse);
+      const promise = global.ZoteroCitationCounts._semanticScholarCallback(mockResponse);
+      await clock.tickAsync(3001);
+      await promise;
       expect(global.Zotero.debug.calledWith(sinon.match(/Semantic Scholar query returned 2 results. Using the first one./))).to.be.true;
     });
     
     it('should return null if direct lookup response has no citationCount', async function() {
         const mockResponse = { paperId: "abcdef123456" }; // Missing citationCount
-        const count = await global.ZoteroCitationCounts._semanticScholarCallback(mockResponse);
+        const promise = global.ZoteroCitationCounts._semanticScholarCallback(mockResponse);
+        await clock.tickAsync(3001);
+        const count = await promise;
         expect(count).to.be.null;
         expect(global.Zotero.debug.calledWith(sinon.match(/Semantic Scholar response did not contain expected citationCount/))).to.be.true;
     });
 
     it('should return null if title search response is empty', async function() {
       const mockResponse = { total: 0, data: [] };
-      const count = await global.ZoteroCitationCounts._semanticScholarCallback(mockResponse);
+      const promise = global.ZoteroCitationCounts._semanticScholarCallback(mockResponse);
+      await clock.tickAsync(3001);
+      const count = await promise;
       expect(count).to.be.null;
       expect(global.Zotero.debug.calledWith(sinon.match(/Semantic Scholar search response did not contain expected citationCount in the first result or no results found/))).to.be.true;
     });
@@ -220,7 +230,9 @@ describe('ZoteroCitationCounts', function() {
         total: 1,
         data: [{ paperId: "zyxwvu987654" }] // Missing citationCount
       };
-      const count = await global.ZoteroCitationCounts._semanticScholarCallback(mockResponse);
+      const promise = global.ZoteroCitationCounts._semanticScholarCallback(mockResponse);
+      await clock.tickAsync(3001);
+      const count = await promise;
       expect(count).to.be.null;
       expect(global.Zotero.debug.calledWith(sinon.match(/Semantic Scholar search response did not contain expected citationCount in the first result or no results found/))).to.be.true;
     });


### PR DESCRIPTION
Integrates Semantic Scholar's paper search API to allow fetching citation counts using title, author, and year metadata when DOI or arXiv IDs are not available.

This change enhances the existing Semantic Scholar integration:
- Modifies `_semanticScholarUrl` and `_semanticScholarCallback` to support constructing search queries and parsing search results.
- Introduces a `useTitleSearch` flag in the API configuration.
- Updates `_retrieveCitationCount` to include a title search step for APIs that support it (currently Semantic Scholar and NASA ADS), following DOI and arXiv lookups.
- Includes comprehensive error handling and prioritization for the new search type.

New integration tests have been added for Semantic Scholar, covering DOI, arXiv, and title search scenarios, including success cases, "not found" cases, insufficient metadata, and API errors. Existing unit tests have also been updated to cover the new URL generation and callback logic for Semantic Scholar.