### PR TITLE
Fix: Narrow unit test scope and remove redundant nyc install

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,11 +26,8 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Install nyc for test coverage
-        run: npm install -g nyc
-
       - name: Run unit tests with coverage
-        run: nyc mocha
+        run: nyc mocha test/unit/**/*.test.js
 
       - name: Check coverage thresholds
         run: nyc check-coverage --lines 80 --functions 80 --branches 80


### PR DESCRIPTION
The GitHub Actions workflow for unit tests was previously running `nyc mocha`, which would attempt to run all tests found in the `test/` directory, including integration tests. This could lead to failures if integration tests were not configured for the CI environment.

This change modifies the workflow to specifically run unit tests using the command `nyc mocha test/unit/**/*.test.js`, mirroring the `test:unit` script in `package.json`.

Additionally, the step for globally installing `nyc` (`npm install -g nyc`) was removed as `nyc` is already a devDependency and available locally, ensuring the project uses the version specified in `package-lock.json` for better reproducibility.